### PR TITLE
Add Category column into Moves’ table for simple organization purposes

### DIFF
--- a/app/controllers/moves_controller.rb
+++ b/app/controllers/moves_controller.rb
@@ -17,7 +17,7 @@ class MovesController < ApplicationController
   end
 
   def index
-    @moves = @character.moves.order(:name)
+    @moves = @character.moves.order(:name).group_by(&:category)
   end
 
   def edit
@@ -46,6 +46,6 @@ class MovesController < ApplicationController
     end
 
     def move_params
-      params.require(:move).permit(:name, :input)
+      params.require(:move).permit(:category, :name, :input)
     end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,4 +1,4 @@
 class Move < ActiveRecord::Base
   belongs_to :character
-  validates :name, :input, presence: true, length: { minimum: 2 }
+  validates :name, :input, :category, presence: true, length: { minimum: 2 }
 end

--- a/app/views/moves/_form.html.erb
+++ b/app/views/moves/_form.html.erb
@@ -14,6 +14,10 @@
 	<% end %>
 
 	<p>
+		<%= m.label :category %><br>
+		<%= m.text_field :category %>
+	</p>
+	<p>
 		<%= m.label :name %><br>
 		<%= m.text_field :name %>
 	</p>

--- a/app/views/moves/edit.html.erb
+++ b/app/views/moves/edit.html.erb
@@ -2,6 +2,10 @@
 
 <%= form_for @move do |m| %>
 	<p>
+		<%= m.label :category %><br>
+		<%= m.text_field :category %>
+	</p>
+	<p>
 		<%= m.label :name %><br>
 		<%= m.text_field :name %>
 	</p>

--- a/app/views/moves/index.html.erb
+++ b/app/views/moves/index.html.erb
@@ -1,6 +1,11 @@
 <h2><%= @character.name %>'s Moves</h2>
 
-<%= render @moves %>
+<% @moves.keys.sort.each do |category| %>
+	<h4><%= category %></h4>
+	<% @moves[category].each do |moves| %>
+		<%= render moves %>
+	<% end %>
+<% end %>
 <% if current_user %>
 <%= link_to 'New move', new_character_move_path %>
 <% end %>

--- a/db/migrate/20160315210219_add_type_to_moves.rb
+++ b/db/migrate/20160315210219_add_type_to_moves.rb
@@ -1,0 +1,5 @@
+class AddTypeToMoves < ActiveRecord::Migration
+  def change
+    add_column :moves, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160217230849) do
+ActiveRecord::Schema.define(version: 20160315210219) do
 
   create_table "characters", force: :cascade do |t|
     t.string   "name"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20160217230849) do
     t.integer  "character_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.string   "category"
   end
 
   add_index "moves", ["character_id"], name: "index_moves_on_character_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,8 +3,31 @@ game = Game.create!(title: "Samurai Shodown 2")
 #Character
 character = game.characters.create!(name: "Genjuro")
 #Moves
-character.moves.create!(name: "Toha Kouyokujin", input: "FDDF+Slash")
-character.moves.create!(name: "Sanrensatsu", input: "QCF+Slash *can be repeated up to 3x")
-character.moves.create!(name: "Oukazan", input: "QCB+Slash")
-character.moves.create!(name: "Super Deformed", input: "HCBFB+B")
-character.moves.create!(name: "Power Special - Gokouzan", input: "HCBF+A")
+character.moves.create!(category: "Special", name: "Toha Kouyokujin",
+                        input: "FDDF+Slash")
+character.moves.create!(category: "Special", name: "Sanrensatsu",
+                        input: "QCF+Slash *can be repeated up to 3x")
+character.moves.create!(category: "Special", name: "Oukazan",
+                        input: "QCB+Slash")
+character.moves.create!(category: "Special", name: "Super Deformed",
+                        input: "HCBFB+B")
+character.moves.create!(category: "Power Special", name: "Gokouzan",
+                        input: "HCBF+A")
+#Another Character and moves
+character = game.characters.create!(name: "Haohmaru")
+character.moves.create!(category: "Special", name: "Kogetsuzan",
+                        input: "FBDDDF+Slash")
+character.moves.create!(category: "Special", name: "Resshin Zan",
+                        input: "FDDF+Kick")
+character.moves.create!(category: "Special", name: "Senpuretsuzan",
+                        input: "QCF+Slash")
+character.moves.create!(category: "Special", name: "False Senpuretsuzan",
+                        input: "QCF+Kick")
+character.moves.create!(category: "Special", name: "Sake Kogeki",
+                        input: "QCB+A")
+character.moves.create!(category: "Special", name: "Kogetsuzen Combo",
+                        input: "DFHCBBDDF+BC")
+character.moves.create!(category: "Special", name: "Super Deformed",
+                        input: "HCBFB+B")
+character.moves.create!(category: "Power Special", name: "Tempa Seikouzan",
+                        input: "FDFDBDBF+A")

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -5,7 +5,7 @@ describe "games", type: :request do
   let(:game_params2) { { game: { title: 'Game2' } } }
   let(:bad_game_params) { { game: { title: '' } } }
   let(:character_params) { { character: { name: 'Bob' } } }
-  let(:move_params) { { move: { name: 'Fireball', input: 'QCF+P' } } }
+  let(:move_params) { { move: { category: 'Special', name: 'Fireball', input: 'QCF+P' } } }
   let(:user) { FactoryGirl.create(:user) }
   let(:user_params) { { email: user.email, password: user.password } }
 

--- a/spec/requests/moves_spec.rb
+++ b/spec/requests/moves_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe "moves", type: :request do
-  let(:move_params) { { move: { name: 'Fireball', input: 'QCF+P' } } }
-  let(:move_params2) { { move: { name: 'Dragon Punch', input: 'FDDF+P' } } }
-  let(:bad_move_params) { { move: { name: '', input: '' } } }
+  let(:move_params) { { move: { category: "Special", name: 'Fireball', input: 'QCF+P' } } }
+  let(:move_params2) { { move: { category: "Special", name: 'Dragon Punch', input: 'FDDF+P' } } }
+  let(:bad_move_params) { { move: { category: '', name: '', input: '' } } }
   let(:character_params) { { character: { name: 'Dan' } } }
   let(:game_params) { { game: { title: 'Game' } } }
   let(:user) { FactoryGirl.create(:user) }


### PR DESCRIPTION
Add category into moves as a new column and using that to do group_by for simple organization when displaying moves for each character. Since this categorization is very simple and straightforward I felt it was not necessary to do a full category model and have that sit between Character and Move.