### PR TITLE
Add email downcase for SignUp and LogIn and update specs

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by_email(params[:email])
+    user = User.find_by_email(params[:email].downcase)
     if user && user.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to root_url, :notice => "Logged in!"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ActiveRecord::Base
   has_secure_password
+  before_validation :downcase_email
   validates_uniqueness_of :email
   validates_format_of :email, with: /@/
   validates :password, length: { minimum: 8 }, allow_nil: true
+
+  private
+    def downcase_email
+      self.email = email.downcase
+    end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "sessions", type: :request do
   let(:user) { FactoryGirl.create(:user) }
-  let(:params) { { email: user.email, password: user.password } }
+  let(:params) { { email: user.email.upcase, password: user.password } }
 
   it "should render the log_in page" do
     get '/log_in'

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -5,6 +5,8 @@ describe "user", type: :request do
   let!(:new_user) { FactoryGirl.build(:user) }
   let(:new_params) {{ user: { email: new_user.email,
     password: new_user.password, password_confirmation: new_user.password} } }
+  let(:new_params2) {{ user: { email: new_user.email.upcase,
+    password: new_user.password, password_confirmation: new_user.password} } }
 
   it "should render the sign up page" do
     get '/sign_up'
@@ -27,4 +29,12 @@ describe "user", type: :request do
     expect(response.body).to include("Email is invalid")
   end
 
+  it "should not create user if new user's email is capitalized of existing" do
+    post '/users', new_params
+    expect(response.code).to eq("302")
+    post '/users', new_params2
+    expect(response).to render_template('new')
+    expect(response.body).to include("Form is invalid")
+    expect(response.body).to include("Email has already been taken")
+  end
 end


### PR DESCRIPTION
Noticed a problem while testing on the iphone that for email fields iOS automatically capitalize the first letter of the email. Add email downcase so that the user does not have to purposely downcase. Add tests to verify downcase is working for both Sign Up and Log In.